### PR TITLE
refactor(api): make PerDestinationConfig optional for optimize-only u…

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -230,8 +230,7 @@ def optimize(request: OptimizeRequest) -> OptimizeResponse:
         destinations_df = _to_destinations_df(request.destinations)
         planning_horizon = sorted(demand_ts["date"].unique().to_list())
 
-        config = PerDestinationConfig(model_names=["naive_forecaster"])
-        api = LogisticsAPI(config=config)
+        api = LogisticsAPI(solver_name="GLOP")
         result = api.optimize(
             demand_ts=demand_ts,
             origins_df=origins_df,

--- a/src/api/logistics_api.py
+++ b/src/api/logistics_api.py
@@ -15,15 +15,16 @@ class LogisticsAPI(APIInterface):
 
     Parameters
     ----------
-    config : PerDestinationConfig
+    config : PerDestinationConfig | None
         Forecasting pipeline configuration (model names, train ratio, etc.).
+        Required for ``forecast``; optional for ``optimize`` -only usage.
     solver_name : str
         OR-Tools backend solver (default ``"GLOP"``).
     """
 
     def __init__(
         self,
-        config: PerDestinationConfig,
+        config: PerDestinationConfig | None = None,
         solver_name: str = "GLOP",
     ) -> None:
         self._config = config
@@ -31,7 +32,10 @@ class LogisticsAPI(APIInterface):
 
     def forecast(self, input_data: pl.DataFrame) -> AggregatedForecastingResult:
         """Run per-destination forecasting on historical demand data."""
-        pipeline = create_forecasting_pipeline(self._config)
+        config = self._config
+        if config is None:
+            raise ValueError("Cannot forecast without a PerDestinationConfig. Pass config= when constructing LogisticsAPI.")
+        pipeline = create_forecasting_pipeline(config)
         return pipeline.run(input_data)
 
     def optimize(


### PR DESCRIPTION
Closes #11 

`POST /optimize` was constructing a dummy `PerDestinationConfig` just to satisfy `LogisticsAPI.__init__`, even though `optimize()` never uses the config. 

Changes:
- Made `config` optional (`None` default) in `LogisticsAPI.__init__`
- Added validation in `forecast()` to raise if config is missing
